### PR TITLE
fix parser for Z3 4.8.10

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1285,7 +1285,8 @@ impl<R: BufRead> SmtParser<R> {
         self.spc_cmt();
         self.try_error()?;
         let mut model = Vec::new();
-        self.tags(&["(", "model"])?;
+        self.tag("(")?;
+        self.try_tag("model")?;
         while !self.try_tag(")")? {
             self.tag_info("(", "opening define-fun or `)` closing model")?;
             self.tag("define-fun")?;
@@ -1320,7 +1321,8 @@ impl<R: BufRead> SmtParser<R> {
         self.spc_cmt();
         self.try_error()?;
         let mut model = Vec::new();
-        self.tags(&["(", "model"])?;
+        self.tag("(")?;
+        self.try_tag("model")?;
         while !self.try_tag(")")? {
             self.tag_info("(", "opening define-fun or `)` closing model")?;
             self.tag("define-fun")?;


### PR DESCRIPTION
Z3 does not output the string "model" when (get-model) from the version 4.8.10.
I changed parse.rs to accept Z3's outputs without "model".