### PR TITLE
v0.13.1 major cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmt2"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Adrien Champion <adrien.champion@email.com>"]
 description = "Wrapper for SMT-LIB 2 compliant SMT solvers."
 documentation = "https://docs.rs/rsmt2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmt2"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Adrien Champion <adrien.champion@email.com>"]
 description = "Wrapper for SMT-LIB 2 compliant SMT solvers."
 documentation = "https://docs.rs/rsmt2"

--- a/changes.md
+++ b/changes.md
@@ -8,7 +8,18 @@
     - take ownership over expressions, symbols and sorts (previously took references)
 
         still accepts refs since `T: Sym2Smt<Info>` ⇒ `&T: Sym2Smt<Info>`, same for `Expr2Smt` and
-        `Sort2Smt`
+        `Sort2Smt`.
+    - `Solver` functions taking collections (iterators) now abstract over what they expect the items
+        to be. Previously, they had to be (constrained) pairs or triplets. They now expect some type
+        implementing the relevant trait for the information they expect (`SymAndSort` for instance).
+        These traits are implemented for the pairs/triplets from previous versions: this new
+        workflow should not break existing code.
+    - **[breaking]** revamp of `declare_datatypes`, see documentation.
+
+## Breaking Changes
+
+- Use of `declare_datatypes` has changed significantly, will most likely break everything. Refer to
+    the documentation for details, sorry.
 
 # v0.13.0
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,15 @@
+# v0.13.1
+
+- added *named assert* function on `Solver`s
+    - `Solver::named_assert_act_with`: named + actlit + print info
+    - `Solver::named_assert_with`: named + print info
+    - `Solver::named_assert`: named
+- simplified most `Solver` function signatures
+    - take ownership over expressions, symbols and sorts (previously took references)
+
+        still accepts refs since `T: Sym2Smt<Info>` ⇒ `&T: Sym2Smt<Info>`, same for `Expr2Smt` and
+        `Sort2Smt`
+
 # v0.13.0
 
 - named expression

--- a/changes.md
+++ b/changes.md
@@ -16,6 +16,8 @@
         workflow should not break existing code.
     - **[breaking]** revamp of `declare_datatypes`, see documentation.
 
+        Relevant traits are `AdtDecl`, `AdtVariant` and `AdtVariantField`.
+
 ## Breaking Changes
 
 - Use of `declare_datatypes` has changed significantly, will most likely break everything. Refer to

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,16 @@
+# v0.13.0
+
+- `Actlit` now implies `Sym2Smt`
+- added `actlit::CondExpr`, which wraps an `Actlit` and a user expression; allows to use `Actlit`s
+  in normal `check-sat` commands
+- named expression
+    - added `NamedExpr<Sym, Expr>` which wraps an expression and a symbol and encodes a named expression
+    - added `into_named` and `as_named` methods on `Expr2Smt` trait for easy expression naming
+    - added `into_name_for` and `as_name_for` methods on `Sym2Smt`
+- unsat cores now working (best used with `NamedExpr` to name expressions)
+    - relies on the `ParseSym` trait to parse symbols from the core
+
+
 # v0.12.0
 
 - adapted parser for Z3's new `get-model` output, which does not use the `model` keyword

--- a/changes.md
+++ b/changes.md
@@ -1,17 +1,22 @@
 # v0.13.0
 
-- `assert`-like functions on `Solver` no longer require the expression to be a reference
-    - goes with `Expr2Smt<Info>` being auto-impl-ed for all `T: Expr2Smt<Info>`
-- `Actlit` now implies `Sym2Smt`
-- added `actlit::CondExpr`, which wraps an `Actlit` and a user expression; allows to use `Actlit`s
-  in normal `check-sat` commands
 - named expression
     - added `NamedExpr<Sym, Expr>` which wraps an expression and a symbol and encodes a named expression
     - added `into_named` and `as_named` methods on `Expr2Smt` trait for easy expression naming
     - added `into_name_for` and `as_name_for` methods on `Sym2Smt`
 - unsat cores now working (best used with `NamedExpr` to name expressions)
     - relies on the `ParseSym` trait to parse symbols from the core
-
+- interpolants (`get-interpolant`) now supported
+    - only Z3 supports this
+    - `SmtConf` produces an error if interpolant production is activated on a non-Z3 solver
+    - uses `Sym2Smt`
+    - best used with `NamedExpr` to name expressions
+- `assert`-like functions on `Solver` no longer require the expression to be a reference
+    - goes with `Expr2Smt<Info>` being auto-impl-ed for all `T: Expr2Smt<Info>`
+- `Actlit` now implies `Sym2Smt`
+- added `actlit::CondExpr`, which wraps an `Actlit` and a user expression; allows to use `Actlit`s
+  in normal `check-sat` commands
+- `SmtConf` now has `set_...` functions for model/unsat core/... production
 
 # v0.12.0
 

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,7 @@
 # v0.13.0
 
+- `assert`-like functions on `Solver` no longer require the expression to be a reference
+    - goes with `Expr2Smt<Info>` being auto-impl-ed for all `T: Expr2Smt<Info>`
 - `Actlit` now implies `Sym2Smt`
 - added `actlit::CondExpr`, which wraps an `Actlit` and a user expression; allows to use `Actlit`s
   in normal `check-sat` commands

--- a/examples/adt.rs
+++ b/examples/adt.rs
@@ -1,0 +1,161 @@
+fn run() {
+    use rsmt2::{
+        print::{SortDecl, SortField, SortVariant},
+        Solver,
+    };
+    let mut solver = Solver::default_z3(()).unwrap();
+
+    // Alright, so we're going to declared two mutually recursive sorts. It is easier to pack the
+    // sort-declaration data in custom types. If you want to declare a sort, you most likely
+    // already have a representation for it, so working on custom types is reasonable.
+
+    // Notice that the `SortDecl`, `SortField` and `SortVariant` traits from `rsmt2::print::_` are in
+    // scope. This is what our custom types will need to generate to declare the sort.
+
+    // We'll use static string slices for simplicity as `&str` implements all printing traits.
+    type Sym = &'static str;
+    type Sort = &'static str;
+
+    // Let's start with the top-level sort type.
+    struct MySort {
+        // Name of the sort, for instance `List`.
+        sym: Sym,
+        // Symbol(s) for the type parameter(s), for instance `T` for `List<T>`. Must be a collection
+        // of known length, because rsmt2 needs to access the arity (number of type parameters).
+        args: Vec<Sym>,
+        // Body of the sort: its variants. For instance the `nil` and `cons` variants for `List<T>`.
+        variants: Vec<Variant>,
+    }
+    impl MySort {
+        // This thing build the actual declaration expected by rsmt2. Its output is something that
+        // implements `SortDecl` and can only live as long as the input ref to `self`.
+        fn as_decl<'me>(&'me self) -> impl SortDecl + 'me {
+            // Check out rsmt2's documentation and you'll see that `SortDecl` is already implemented for
+            // certain triplets.
+            (
+                // Symbol.
+                &self.sym,
+                // Sized collection of type-parameter symbols.
+                &self.args,
+                // Variant, collection of iterator over `impl SortVariant` (see below).
+                self.variants.iter().map(Variant::as_decl),
+            )
+        }
+
+        fn tree() -> Self {
+            Self {
+                sym: "Tree",
+                args: vec!["T"],
+                variants: vec![Variant::tree_leaf(), Variant::tree_node()],
+            }
+        }
+    }
+
+    // Next up, variants. A variant is a symbol (*e.g.* `nil` or `cons` for `List<T>`) and some
+    // fields which describe the data stored in the variant.
+    struct Variant {
+        sym: Sym,
+        fields: Vec<Field>,
+    }
+    impl Variant {
+        // Variant declaration; again, `SortVariant` is implemented for certain types of pairs.
+        fn as_decl<'me>(&'me self) -> impl SortVariant + 'me {
+            (
+                // Symbol.
+                self.sym,
+                // Iterator over field declarations.
+                self.fields.iter().map(Field::as_decl),
+            )
+        }
+
+        fn tree_leaf() -> Self {
+            Self {
+                sym: "leaf",
+                fields: vec![],
+            }
+        }
+        fn tree_node() -> Self {
+            Self {
+                sym: "node",
+                fields: vec![Field::tree_node_value(), Field::tree_node_children()],
+            }
+        }
+    }
+
+    // A symbol and a sort: describes a piece of data in a variant with a symbol to retrieve it,
+    // *i.e.* the name of the field.
+    struct Field {
+        sym: Sym,
+        sort: Sort,
+    }
+    impl Field {
+        // As usual, `SortField` is implemented for certain pairs.
+        fn as_decl(&self) -> impl SortField {
+            (self.sym, self.sort)
+        }
+
+        fn tree_node_value() -> Self {
+            Self {
+                sym: "value",
+                sort: "T",
+            }
+        }
+        fn tree_node_children() -> Self {
+            Self {
+                sym: "children",
+                sort: "(TreeList T)",
+            }
+        }
+    }
+
+    let tree = MySort::tree();
+
+    // Now this `tree` uses an non-existing `(TreeList T)` sort to store its children, let's declare
+    // it now.
+
+    let nil = Variant {
+        sym: "nil",
+        fields: vec![],
+    };
+    let cons = Variant {
+        sym: "cons",
+        fields: vec![
+            Field {
+                sym: "car",
+                sort: "(Tree T)",
+            },
+            Field {
+                sym: "cdr",
+                sort: "(TreeList T)",
+            },
+        ],
+    };
+    let tree_list = MySort {
+        sym: "TreeList",
+        args: vec!["T"],
+        variants: vec![nil, cons],
+    };
+
+    solver
+        // These sort are mutually recursive, `Solver::declare_datatypes` needs to declare them at the
+        // same time.
+        .declare_datatypes(&[tree.as_decl(), tree_list.as_decl()])
+        .unwrap();
+
+    // That's it! Solver now knows these sorts and we can use them.
+
+    solver.declare_const("t1", "(Tree Int)").unwrap();
+    solver.declare_const("t2", "(Tree Bool)").unwrap();
+
+    solver.assert("(> (value t1) 20)").unwrap();
+    solver.assert("(not (is-leaf t2))").unwrap();
+    solver.assert("(not (value t2))").unwrap();
+
+    let sat = solver.check_sat().unwrap();
+    assert!(sat);
+}
+
+fn main() {
+    run();
+    println!("everything is fine");
+}

--- a/src/actlit.rs
+++ b/src/actlit.rs
@@ -3,26 +3,26 @@
 //! For an explanation of what activation literal are, see [the discussion below][why actlits].
 //!
 //! **NB**: while `rmst2`'s actlit API declares some constant symbols in the underlying solver,
-//! these will not appear in the result of [`get_model`](super::Solver::get_model) queries.
+//! these will not appear in the result of [`Solver::get_model`] queries.
 //!
 //!
-//! # Relevant functions on [`Solver`](super::Solver)s
+//! # Relevant functions on [`Solver`]s
 //!
-//! - [`Solver::get_actlit`](super::Solver::get_actlit)
-//! - [`Solver::de_actlit`](super::Solver::de_actlit)
-//! - [`Solver::set_actlit`](super::Solver::set_actlit)
-//! - [`Solver::assert_act`](super::Solver::assert_act)
-//! - [`Solver::assert_act_with`](super::Solver::assert_act_with)
-//! - [`Solver::print_check_sat_act`](super::Solver::print_check_sat_act)
-//! - [`Solver::check_sat_act`](super::Solver::check_sat_act)
-//! - [`Solver::check_sat_act_or_unk`](super::Solver::check_sat_act_or_unk)
+//! - [`Solver::get_actlit`]
+//! - [`Solver::de_actlit`]
+//! - [`Solver::set_actlit`]
+//! - [`Solver::assert_act`]
+//! - [`Solver::assert_act_with`]
+//! - [`Solver::print_check_sat_act`]
+//! - [`Solver::check_sat_act`]
+//! - [`Solver::check_sat_act_or_unk`]
 //!
 //!
 //!
 //! # Usage
 //!
 //! First, one can of course create activation literals by hand, and use them in `check-sat`s with
-//! [`check_sat_assuming`](super::Solver::check_sat_assuming):
+//! [`Solver::check_sat_assuming`]:
 //!
 //! ```
 //! use rsmt2::*;
@@ -222,16 +222,20 @@
 //! (get-value (x))
 //! ```
 //!
-//! This is much more efficient than `push`/`pop`: the conditional `check-sat`s basically force the
-//! activation literals directly in the SAT part of the SMT solver. Long story short, this means
-//! everything the solver learns during the checks is still valid afterwards. Conversely, after a
-//! `pop` solvers are usually unable to decide what to keep from the checks before the `pop`, and
-//! thus drop everything.
+//! This is much more efficient than [`push`][Solver::push]/[`pop`][Solver::pop]: the conditional
+//! `check-sat`s basically force the activation literals directly in the SAT part of the SMT solver.
+//! Long story short, this means everything the solver learns during the checks is still valid
+//! afterwards. Conversely, after a `pop` solvers are usually unable to decide what to keep from the
+//! checks before the `pop`, and thus drop everything.
 //!
-//! Actlits are **not** equivalent to `push`/`pop` however. Pushing a scope allows to declare/define
-//! function symbols and then discard them, while keeping whatever's outside of the scope. Actlits
-//! (mostly) just guard assertions and cannot accomplish this.
+//! Actlits are **not** equivalent to [`push`][Solver::push]/[`pop`][Solver::pop] however. Pushing a
+//! scope allows to declare/define function symbols and then discard them, while keeping whatever's
+//! outside of the scope. Actlits (mostly) just guard assertions and cannot accomplish this.
 //!
 //! [why actlits]: #discussion-on-activation-literals (Activation literals, why?)
+
+#[allow(unused_imports)]
+// Only used by doc links.
+use crate::Solver;
 
 pub use crate::solver::Actlit;

--- a/src/actlit.rs
+++ b/src/actlit.rs
@@ -252,6 +252,11 @@ pub struct Actlit {
     /// ID of the actlit.
     pub(crate) id: usize,
 }
+impl AsRef<Actlit> for Actlit {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
 impl Actlit {
     /// Constructor.
     pub(crate) fn new(id: usize) -> Self {

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -53,20 +53,20 @@
 //!
 //!         // Non-blocking.
 //!         let maybe_result = future.try_get();
-//!         assert! { maybe_result.is_none() }
+//!         assert!(maybe_result.is_none());
 //!
 //!         // Blocking with timeout.
 //!         let maybe_result = future.timeout_get(std::time::Duration::new(0, 50));
-//!         assert! { maybe_result.is_none() }
+//!         assert!(maybe_result.is_none());
 //!
 //!         // Blocking.
 //!         let result = future.get();
-//!         assert! { result.expect("reached timeout").is_none() }
+//!         assert!(result.expect("reached timeout").is_none());
 //!     }
 //!
 //!     // We can re-use the solver now.
 //!     let result = solver.check_sat_or_unk();
-//!     assert! { result.expect("reached timeout").is_none() }
+//!     assert!(result.expect("reached timeout").is_none());
 //!
 //!     Ok(())
 //! }

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -1,7 +1,6 @@
 //! This modules handles asynchronous interactions with the solver.
 //!
-//! The related function is
-//! [`Solver::async_check_sat_or_unk`](crate::Solver::async_check_sat_or_unk).
+//! The related function is [`Solver::async_check_sat_or_unk`].
 //!
 //! Presently, only asynchronous check-sat-s are supported. The idea is to wrap the whole solver in
 //! a new thread, and yield a future of the check-sat result. The new thread starts parsing the
@@ -20,8 +19,8 @@
 //! > solver with the right options to add a timeout. For Z3, `-t:500` for a (soft, per query)
 //! > timeout, which makes it report `unknown`. This is what the examples below do.
 //! >
-//! > This is why [`Solver::async_check_sat_or_unk`](crate::Solver::async_check_sat_or_unk) is
-//! > marked `unsafe`: if not careful, one can end up with a background process burning 100% CPU.
+//! > This is why [`Solver::async_check_sat_or_unk`] is marked `unsafe`: if not careful, one can end
+//! > up with a background process burning 100% CPU.
 //!
 //! # Examples
 //!

--- a/src/common.rs
+++ b/src/common.rs
@@ -130,7 +130,8 @@ impl Sort2Smt for String {
 /// use rsmt2::prelude::*;
 /// let mut conf = SmtConf::default_z3();
 /// conf.unsat_cores();
-/// println!("unsat_cores: {}", conf.get_unsat_cores());
+/// # println!("unsat_cores: {}", conf.get_unsat_cores());
+///
 /// let mut solver = Solver::new(conf, ()).unwrap();
 /// solver.declare_const("n", "Int").unwrap();
 /// solver.declare_const("m", "Int").unwrap();
@@ -149,6 +150,7 @@ impl Sort2Smt for String {
 ///
 /// assert!(!solver.check_sat().unwrap());
 /// let core: Vec<String> = solver.get_unsat_core().unwrap();
+/// assert_eq!(core, vec![label_e_1, label_e_2]);
 /// ```
 pub struct NamedExpr<Sym, Expr> {
     /// Symbol.

--- a/src/common.rs
+++ b/src/common.rs
@@ -31,6 +31,51 @@ pub trait Sort2Smt {
         Writer: io::Write;
 }
 
+/// A symbol and a sort, implemented by by symbol/sort pairs.
+///
+/// Implement this trait if you want to use your own data structures in solver functions working on
+/// lists of sorted symbols. For example,
+///
+/// - [Solver::define_fun][crate::Solver::define_fun]
+/// - [Solver::define_funs_rec_with][crate::Solver::define_funs_rec_with]
+pub trait SymAndSort<Info> {
+    /// Type of the symbol.
+    type Sym: Sym2Smt<Info>;
+    /// Type of the sort.
+    type Sort: Sym2Smt<Info>;
+    /// Symbol accessor.
+    fn sym(&self) -> &Self::Sym;
+    /// Sort accessor.
+    fn sort(&self) -> &Self::Sort;
+}
+impl<'a, T, Info> SymAndSort<Info> for &'a T
+where
+    T: SymAndSort<Info>,
+{
+    type Sym = <T as SymAndSort<Info>>::Sym;
+    type Sort = <T as SymAndSort<Info>>::Sort;
+    fn sym(&self) -> &Self::Sym {
+        (*self).sym()
+    }
+    fn sort(&self) -> &Self::Sort {
+        (*self).sort()
+    }
+}
+impl<Info, Sym, Sort> SymAndSort<Info> for (Sym, Sort)
+where
+    Sym: Sym2Smt<Info>,
+    Sort: Sym2Smt<Info>,
+{
+    type Sym = Sym;
+    type Sort = Sort;
+    fn sym(&self) -> &Sym {
+        &self.0
+    }
+    fn sort(&self) -> &Sort {
+        &self.1
+    }
+}
+
 /// Writes a string.
 #[inline(always)]
 pub fn write_str<W: io::Write>(w: &mut W, s: &str) -> SmtRes<()> {

--- a/src/common.rs
+++ b/src/common.rs
@@ -145,15 +145,15 @@ where
     }
 }
 
-pub trait SortField {
+pub trait AdtVariantField {
     type FieldSym: Sym2Smt;
     type FieldSort: Sort2Smt;
     fn sym(&self) -> &Self::FieldSym;
     fn sort(&self) -> &Self::FieldSort;
 }
-impl<'a, T> SortField for &'a T
+impl<'a, T> AdtVariantField for &'a T
 where
-    T: SortField,
+    T: AdtVariantField,
 {
     type FieldSym = T::FieldSym;
     type FieldSort = T::FieldSort;
@@ -164,7 +164,7 @@ where
         (*self).sort()
     }
 }
-impl<FieldSym, FieldSort> SortField for (FieldSym, FieldSort)
+impl<FieldSym, FieldSort> AdtVariantField for (FieldSym, FieldSort)
 where
     FieldSym: Sym2Smt,
     FieldSort: Sort2Smt,
@@ -180,17 +180,17 @@ where
     }
 }
 
-pub trait SortVariant {
+pub trait AdtVariant {
     type VariantSym: Sym2Smt;
-    type Field: SortField;
+    type Field: AdtVariantField;
     type FieldIter: Iterator<Item = Self::Field>;
 
     fn sym(&self) -> &Self::VariantSym;
     fn fields(&self) -> Self::FieldIter;
 }
-impl<'a, T> SortVariant for &'a T
+impl<'a, T> AdtVariant for &'a T
 where
-    T: SortVariant,
+    T: AdtVariant,
 {
     type VariantSym = T::VariantSym;
     type Field = T::Field;
@@ -203,10 +203,10 @@ where
         (*self).fields()
     }
 }
-impl<VariantSym, Field, FieldIntoIter> SortVariant for (VariantSym, FieldIntoIter)
+impl<VariantSym, Field, FieldIntoIter> AdtVariant for (VariantSym, FieldIntoIter)
 where
     VariantSym: Sym2Smt,
-    Field: SortField,
+    Field: AdtVariantField,
     FieldIntoIter: IntoIterator<Item = Field> + Clone,
 {
     type VariantSym = VariantSym;
@@ -221,14 +221,14 @@ where
     }
 }
 
-pub trait SortDecl {
+pub trait AdtDecl {
     type SortSym: Sym2Smt;
     type VariantSym: Sym2Smt;
 
     type SortArg: Sym2Smt;
     type ArgsIter: Iterator<Item = Self::SortArg> + ExactSizeIterator;
 
-    type Variant: SortVariant;
+    type Variant: AdtVariant;
     type VariantIter: Iterator<Item = Self::Variant>;
 
     fn sort_sym(&self) -> &Self::SortSym;
@@ -238,14 +238,14 @@ pub trait SortDecl {
     }
     fn variants(&self) -> Self::VariantIter;
 }
-impl<SortSym, ArgsIntoIter, VariantIntoIter> SortDecl for (SortSym, ArgsIntoIter, VariantIntoIter)
+impl<SortSym, ArgsIntoIter, VariantIntoIter> AdtDecl for (SortSym, ArgsIntoIter, VariantIntoIter)
 where
     SortSym: Sym2Smt,
     ArgsIntoIter: IntoIterator + Clone,
     ArgsIntoIter::IntoIter: ExactSizeIterator,
     ArgsIntoIter::Item: Sym2Smt,
     VariantIntoIter: IntoIterator + Clone,
-    VariantIntoIter::Item: SortVariant,
+    VariantIntoIter::Item: AdtVariant,
 {
     type SortSym = SortSym;
     type VariantSym = ArgsIntoIter::Item;
@@ -266,9 +266,9 @@ where
         self.2.clone().into_iter()
     }
 }
-impl<'a, T> SortDecl for &'a T
+impl<'a, T> AdtDecl for &'a T
 where
-    T: SortDecl,
+    T: AdtDecl,
 {
     type SortSym = T::SortSym;
     type VariantSym = T::VariantSym;

--- a/src/common.rs
+++ b/src/common.rs
@@ -124,7 +124,7 @@ impl Sort2Smt for String {
     }
 }
 
-/// SMT Lib 2 logics, used with [`Solver::set_logic`](super::Solver::set_logic).
+/// SMT Lib 2 logics, used with [`Solver::set_logic`][crate::Solver::set_logic].
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy)]
 pub enum Logic {

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -194,10 +194,10 @@ impl fmt::Display for SmtStyle {
 
 /// Configuration and solver specific info.
 ///
-/// - [z3][z3]: full support
-/// - [cvc4][cvc4]: full support in theory, but only partially tested. Note that `get-value` is
+/// - [z3]: full support
+/// - [cvc4]: full support in theory, but only partially tested. Note that `get-value` is
 ///   known to crash some versions of CVC4.
-/// - [yices 2][yices 2]: full support in theory, but only partially tested. Command `get-model`
+/// - [yices 2]: full support in theory, but only partially tested. Command `get-model`
 ///   will only work on Yices 2 > `2.6.1`, and needs to be activated with [`Self::models`]. To
 ///   understand why, see <https://github.com/SRI-CSL/yices2/issues/162>.
 ///   

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -634,7 +634,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.models();
-    /// assert! { conf.get_models() }
+    /// assert!(conf.get_models());
     /// ```
     pub fn models(&mut self) {
         self.set_models(true)
@@ -647,7 +647,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.set_models(false);
-    /// assert! { !conf.get_models() }
+    /// assert!(!conf.get_models());
     /// ```
     pub fn set_models(&mut self, val: bool) {
         self.models = val;
@@ -667,7 +667,7 @@ impl SmtConf {
     /// ```rust
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
-    /// assert! { conf.get_incremental() }
+    /// assert!(conf.get_incremental());
     /// ```
     pub fn get_incremental(&self) -> bool {
         self.incremental
@@ -680,7 +680,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.incremental();
-    /// assert! { conf.get_incremental() }
+    /// assert!(conf.get_incremental());
     /// ```
     pub fn incremental(&mut self) {
         self.set_incremental(true)
@@ -693,7 +693,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.incremental();
-    /// assert! { conf.get_incremental() }
+    /// assert!(conf.get_incremental());
     /// ```
     pub fn set_incremental(&mut self, val: bool) {
         self.incremental = val;
@@ -711,7 +711,7 @@ impl SmtConf {
     ///
     /// ```rust
     /// # use rsmt2::SmtConf;
-    /// assert! { ! SmtConf::default_z3().get_unsat_cores() }
+    /// assert!(! SmtConf::default_z3().get_unsat_cores());
     /// ```
     #[inline]
     pub fn get_unsat_cores(&self) -> bool {
@@ -725,7 +725,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.unsat_cores();
-    /// assert! { conf.get_unsat_cores() }
+    /// assert!(conf.get_unsat_cores());
     /// ```
     #[inline]
     pub fn unsat_cores(&mut self) {
@@ -739,7 +739,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.set_unsat_cores(false);
-    /// assert! { !conf.get_unsat_cores() }
+    /// assert!(!conf.get_unsat_cores());
     /// ```
     #[inline]
     pub fn set_unsat_cores(&mut self, val: bool) {
@@ -767,7 +767,7 @@ impl SmtConf {
     ///
     /// ```rust
     /// # use rsmt2::SmtConf;
-    /// assert! { ! SmtConf::default_z3().get_print_success() }
+    /// assert!(! SmtConf::default_z3().get_print_success());
     /// ```
     #[inline]
     #[cfg(not(no_parse_success))]
@@ -782,7 +782,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.print_success();
-    /// assert! { conf.get_print_success() }
+    /// assert!(conf.get_print_success());
     /// ```
     #[inline]
     #[cfg(not(no_parse_success))]
@@ -797,7 +797,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.set_print_success(true);
-    /// assert! { conf.get_print_success() }
+    /// assert!(conf.get_print_success());
     /// ```
     #[inline]
     #[cfg(not(no_parse_success))]
@@ -811,7 +811,7 @@ impl SmtConf {
     ///
     /// ```rust
     /// # use rsmt2::SmtConf;
-    /// assert! { SmtConf::default_z3().get_interpolants() }
+    /// assert!(SmtConf::default_z3().get_interpolants());
     /// ```
     #[inline]
     pub fn get_interpolants(&self) -> bool {
@@ -825,7 +825,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.interpolants();
-    /// assert! { conf.get_interpolants() }
+    /// assert!(conf.get_interpolants());
     /// ```
     #[inline]
     pub fn interpolants(&mut self) -> SmtRes<()> {
@@ -839,7 +839,7 @@ impl SmtConf {
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
     /// conf.set_interpolants(false);
-    /// assert! { !conf.get_interpolants() }
+    /// assert!(!conf.get_interpolants());
     /// ```
     #[inline]
     pub fn set_interpolants(&mut self, val: bool) -> SmtRes<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,7 @@ pub mod examples {}
 
 /// Traits your types must implement so that rsmt2 can use them.
 pub mod print {
-    pub use crate::common::{Expr2Smt, Sort2Smt, Sym2Smt};
+    pub use crate::common::{Expr2Smt, Sort2Smt, Sym2Smt, SymAndSort};
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,16 +13,15 @@
 //!
 //! In rsmt2, solvers run in a separate process and communication is achieved *via* system pipes.
 //! This means that to use a solver, it needs to be available as a binary in your path. For the
-//! moment, only [z3][z3] is officially supported, although there is experimental support for
-//! [cvc4][cvc4] and [yices 2][yices 2].
+//! moment, only [z3] is officially supported, although there is experimental support for [cvc4] and
+//! [yices 2].
 //!
 //! **NB**: most of the tests and documentation examples in this crate will not work unless you have
-//! [z3][z3] in your path under the name `z3`.
+//! [z3] in your path under the name `z3`.
 //!
 //! This library does **not** have a structure for S-expressions. It must be provided by the user,
 //! as well as the relevant printing and parsing functions. Printing-related traits are discussed in
-//! the [`print`](self::print) module, and parsing-related traits are in the [`parse`](self::parse)
-//! module.
+//! the [`mod@print`] module, and parsing-related traits are in the [`mod@parse`] module.
 //!
 //!
 //! # Note on Backend Solvers
@@ -30,8 +29,8 @@
 //! This crate supports the following solvers:
 //!
 //! - [z3]: full support
-//! - [cvc4]: full support in theory, but only partially tested. Note that `get-value` is
-//!   known to crash some versions of CVC4.
+//! - [cvc4]: full support in theory, but only partially tested. Note that `get-value` is known to
+//!   crash some versions of CVC4.
 //! - [yices 2]: full support in theory, but only partially tested. Command `get-model` will only
 //!   work on Yices 2 > `2.6.1`, and needs to be activated with [`SmtConf::models`]. To understand
 //!   why, see <https://github.com/SRI-CSL/yices2/issues/162>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,9 @@ pub mod examples {}
 
 /// Traits your types must implement so that rsmt2 can use them.
 pub mod print {
-    pub use crate::common::{Expr2Smt, Sort2Smt, Sym2Smt, SymAndSort};
+    pub use crate::common::{
+        Expr2Smt, Sort2Smt, SortDecl, SortField, SortVariant, Sym2Smt, SymAndSort,
+    };
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! solver.assert("(= (+ (* n n) (* m m)) 7)")?;
 //!
 //! let is_sat = solver.check_sat()?;
-//! assert! { ! is_sat }
+//! assert!(! is_sat);
 //! # Ok(())
 //! # }
 //! # do_smt_stuff().unwrap()
@@ -156,16 +156,16 @@
 //! solver.assert("(and (< n 5) (> n 0) (> m 0))")?;
 //!
 //! let is_sat = solver.check_sat()?;
-//! assert! { is_sat }
+//! assert!(is_sat);
 //! let mut model = solver.get_model()?;
 //! model.sort(); // Order might vary, sorting for assert below.
-//! assert_eq! {
+//! assert_eq!(
 //!     model,
 //!     vec![
 //!         ("m".into(), vec![], "Int".into(), "5".into()),
 //!         ("n".into(), vec![], "Int".into(), "2".into()),
 //!     ]
-//! }
+//! );
 //! # Ok(())
 //! # }
 //! # do_smt_stuff().unwrap()
@@ -222,7 +222,7 @@
 //! let my_check_sat = solver.print_check_sat()?;
 //! // Solver is working, we can do other things.
 //! let is_sat = solver.parse_check_sat(my_check_sat)?;
-//! assert! { is_sat }
+//! assert!(is_sat);
 //! # Ok(())
 //! # }
 //! # do_smt_stuff().unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,9 @@ extern crate error_chain;
 
 /// Common rsmt2 type and helpers.
 pub mod prelude {
-    pub use super::{errors::SmtRes, parse::*, print::*, SmtConf, Solver};
+    pub use crate::{
+        actlit, common::NamedExpr, errors::SmtRes, parse::*, print::*, SmtConf, Solver,
+    };
 }
 
 /// Errors.
@@ -451,7 +453,7 @@ pub mod conf;
 pub mod parse;
 mod solver;
 
-pub use crate::common::Logic;
+pub use crate::common::{Logic, NamedExpr};
 pub use crate::conf::{SmtConf, SmtStyle};
 pub use crate::errors::SmtRes;
 pub use crate::solver::Solver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,7 +473,7 @@ pub mod examples {}
 /// Traits your types must implement so that rsmt2 can use them.
 pub mod print {
     pub use crate::common::{
-        Expr2Smt, Sort2Smt, SortDecl, SortField, SortVariant, Sym2Smt, SymAndSort,
+        AdtDecl, AdtVariant, AdtVariantField, Expr2Smt, Sort2Smt, Sym2Smt, SymAndSort,
     };
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,7 @@
 //!
 //!
 //! Here is a first example where we defined a value parser that only recognizes booleans, to
-//! showcase [`ValueParser`] and [`Solver::get_values`](super::Solver::get_values). `Expr`essions
+//! showcase [`ValueParser`] and [`Solver::get_values`][crate::Solver::get_values]. `Expr`essions
 //! are represented as strings, and `Val`ues are booleans.
 //!
 //! ```rust
@@ -1375,7 +1375,7 @@ impl<R: BufRead> SmtParser<R> {
     }
 }
 
-/// Can parse identifiers and types. Used for `get_model`.
+/// Can parse identifiers and types. Used for [`Solver::get_model`][crate::Solver::get_model].
 ///
 /// For more information refer to the [module-level documentation](self).
 pub trait IdentParser<Ident, Type, Input>: Copy {
@@ -1408,7 +1408,7 @@ where
     }
 }
 
-/// Can parse models. Used for `get-model`.
+/// Can parse models. Used for [`Solver::get_model`][crate::Solver::get_model].
 ///
 /// For more information refer to the [module-level documentation](self).
 pub trait ModelParser<Ident, Type, Value, Input>: Copy {
@@ -1462,7 +1462,7 @@ where
     }
 }
 
-/// Can parse values. Used for `get-value`.
+/// Can parse values. Used for [`Solver::get_values`][crate::Solver::get_values].
 ///
 /// For more information refer to the [module-level documentation](self).
 pub trait ValueParser<Value, Input>: Copy {
@@ -1487,7 +1487,7 @@ where
     }
 }
 
-/// Can parse expressions. Used for `get_value`.
+/// Can parse expressions. Used for [`Solver::get_values`][crate::Solver::get_values].
 ///
 /// For more information refer to the [module-level documentation](self).
 pub trait ExprParser<Expr, Info, Input>: Copy {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1285,6 +1285,7 @@ impl<R: BufRead> SmtParser<R> {
             core.push(parser.parse_sym(self)?);
             self.spc_cmt();
         }
+        self.clear();
         Ok(core)
     }
 
@@ -1324,7 +1325,7 @@ impl<R: BufRead> SmtParser<R> {
         Ok(model)
     }
 
-    /// Parses the result of a get-model.
+    /// Parses the result of a `get-model`.
     pub fn get_model<Ident, Value, Type, Parser>(
         &mut self,
         prune_actlits: bool,
@@ -1373,7 +1374,7 @@ impl<R: BufRead> SmtParser<R> {
         Ok(model)
     }
 
-    /// Parses the result of a get-value.
+    /// Parses the result of a `get-value`.
     pub fn get_values<Val, Info: Clone, Expr, Parser>(
         &mut self,
         parser: Parser,
@@ -1396,6 +1397,22 @@ impl<R: BufRead> SmtParser<R> {
         }
         self.clear();
         Ok(values)
+    }
+
+    /// Parses the result of a `get-interpolant`.
+    pub fn get_interpolant<Expr, Info, Parser>(
+        &mut self,
+        parser: Parser,
+        info: Info,
+    ) -> SmtRes<Expr>
+    where
+        Parser: for<'a> ExprParser<Expr, Info, &'a mut Self>,
+    {
+        self.spc_cmt();
+        self.try_error()?;
+        let expr = parser.parse_expr(self, info)?;
+        self.clear();
+        Ok(expr)
     }
 }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -702,14 +702,14 @@ impl<Parser> Solver<Parser> {
     /// # Examples
     ///
     /// ```rust
-    /// use rsmt2::print::{SortDecl, SortField, SortVariant};
+    /// use rsmt2::print::{AdtDecl, AdtVariantField, AdtVariant};
     ///
     /// // Alright, so we're going to declare two mutually recursive sorts. It is easier to pack the
     /// // sort-declaration data in custom types. If you want to declare a sort, you most likely
     /// // already have a representation for it, so working on custom types is reasonable.
     ///
-    /// // Notice that the `SortDecl`, `SortField` and `SortVariant` traits from `rsmt2::print::_` are in
-    /// // scope. This is what our custom types will need to generate to declare the sort.
+    /// // Notice that the `AdtDecl`, `AdtVariantField` and `AdtVariant` traits from `rsmt2::print::_`
+    /// // are in scope. This is what our custom types will need to generate to declare the sort.
     ///
     /// // We'll use static string slices for simplicity as `&str` implements all printing traits.
     /// type Sym = &'static str;
@@ -727,16 +727,16 @@ impl<Parser> Solver<Parser> {
     /// }
     /// impl MySort {
     ///     // This thing build the actual definition expected by rsmt2. Its output is something that
-    ///     // implements `SortDecl` and can only live as long as the input ref to `self`.
-    ///     fn as_decl<'me>(&'me self) -> impl SortDecl + 'me {
-    ///         // Check out rsmt2's documentation and you'll see that `SortDecl` is already implemented for
+    ///     // implements `AdtDecl` and can only live as long as the input ref to `self`.
+    ///     fn as_decl<'me>(&'me self) -> impl AdtDecl + 'me {
+    ///         // Check out rsmt2's documentation and you'll see that `AdtDecl` is already implemented for
     ///         // certain triplets.
     ///         (
     ///             // Symbol.
     ///             &self.sym,
     ///             // Sized collection of type-parameter symbols.
     ///             &self.args,
-    ///             // Variant, collection of iterator over `impl SortVariant` (see below).
+    ///             // Variant, collection of iterator over `impl AdtVariant` (see below).
     ///             self.variants.iter().map(Variant::as_decl),
     ///         )
     ///     }
@@ -757,8 +757,8 @@ impl<Parser> Solver<Parser> {
     ///     fields: Vec<Field>,
     /// }
     /// impl Variant {
-    ///     // Variant declaration; again, `SortVariant` is implemented for certain types of pairs.
-    ///     fn as_decl<'me>(&'me self) -> impl SortVariant + 'me {
+    ///     // Variant declaration; again, `AdtVariant` is implemented for certain types of pairs.
+    ///     fn as_decl<'me>(&'me self) -> impl AdtVariant + 'me {
     ///         (
     ///             // Symbol.
     ///             self.sym,
@@ -788,8 +788,8 @@ impl<Parser> Solver<Parser> {
     ///     sort: Sort,
     /// }
     /// impl Field {
-    ///     // As usual, `SortField` is implemented for certain pairs.
-    ///     fn as_decl(&self) -> impl SortField {
+    ///     // As usual, `AdtVariantField` is implemented for certain pairs.
+    ///     fn as_decl(&self) -> impl AdtVariantField {
     ///         (self.sym, self.sort)
     ///     }
     ///
@@ -858,7 +858,7 @@ impl<Parser> Solver<Parser> {
     pub fn declare_datatypes<Defs>(&mut self, defs: Defs) -> SmtRes<()>
     where
         Defs: IntoIterator + Clone,
-        Defs::Item: SortDecl,
+        Defs::Item: AdtDecl,
     {
         tee_write! {
           self, |w| write!(w, "(declare-datatypes (") ?

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -434,9 +434,9 @@ impl<Parser> Solver<Parser> {
     /// # use rsmt2::Solver;
     /// let mut solver = Solver::default_z3(()).unwrap();
     /// solver.assert("(= 0 1)").unwrap();
-    /// assert! { ! solver.check_sat().unwrap() }
+    /// assert!(! solver.check_sat().unwrap());
     /// solver.reset().unwrap();
-    /// assert! { solver.check_sat().unwrap() }
+    /// assert!(solver.check_sat().unwrap());
     /// ```
     #[inline]
     pub fn reset(&mut self) -> SmtRes<()> {
@@ -734,7 +734,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust
     /// # use rsmt2::Solver;
     /// let mut solver = Solver::default_z3(()).unwrap();
     /// solver.declare_datatypes( & [
@@ -752,7 +752,7 @@ impl<Parser> Solver<Parser> {
     /// solver.assert("(not (value t2))").unwrap();
     ///
     /// let sat = solver.check_sat().unwrap();
-    /// assert! { sat } panic! { "aaa" }
+    /// assert!(sat);
     /// ```
     pub fn declare_datatypes<'a, Sort, Param, ParamList, Def, DefList, All>(
         &mut self,
@@ -893,6 +893,24 @@ impl<Parser> Solver<Parser> {
     }
 
     /// Get-unsat-core command.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rsmt2::Solver;
+    ///
+    /// let mut solver = Solver::default_z3(()).unwrap();
+    ///
+    /// solver.declare_const("x", "Int").unwrap();
+    /// solver.declare_const("y", "Int").unwrap();
+    ///
+    /// solver.assert("(= (+ x y) 0)").unwrap();
+    ///
+    /// let future = solver.print_check_sat().unwrap();
+    /// // Do stuff while the solver works.
+    /// let sat = solver.parse_check_sat(future).unwrap();
+    /// assert!(sat);
+    /// ```
     pub fn get_unsat_core<Sym>(&mut self) -> SmtRes<Vec<Sym>>
     where
         Parser: for<'a> SymParser<Sym, &'a mut RSmtParser>,
@@ -1043,7 +1061,7 @@ impl<Parser> Solver<Parser> {
     /// let future = solver.print_check_sat().unwrap();
     /// // Do stuff while the solver works.
     /// let sat = solver.parse_check_sat(future).unwrap();
-    /// assert! { sat }
+    /// assert!(sat);
     /// ```
     #[inline]
     pub fn print_check_sat(&mut self) -> SmtRes<FutureCheckSat> {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -65,7 +65,7 @@ fn future_check_sat() -> FutureCheckSat {
 
 /// Solver providing most of the SMT-LIB 2.5 commands.
 ///
-/// Note the [`tee` function](Self::tee), which takes a file writer to which it will write
+/// Note the [`Self::tee`] function, which takes a file writer to which it will write
 /// everything sent to the solver.
 pub struct Solver<Parser> {
     /// Solver configuration.
@@ -219,7 +219,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// The command used to run a particular solver is up to the end-user. As such, it **does not
     /// make sense** to use default commands for anything else than local testing. You should
-    /// explicitely pass the command to use with [`Self::z3`](Self::z3) instead.
+    /// explicitely pass the command to use with [`Self::z3`] instead.
     pub fn default_z3(parser: Parser) -> SmtRes<Self> {
         Self::new(SmtConf::default_z3(), parser)
     }
@@ -233,7 +233,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// The command used to run a particular solver is up to the end-user. As such, it **does not
     /// make sense** to use default commands for anything else than local testing. You should
-    /// explicitely pass the command to use with [`Self::cvc4`](Self::cvc4) instead.
+    /// explicitely pass the command to use with [`Self::cvc4`] instead.
     pub fn default_cvc4(parser: Parser) -> SmtRes<Self> {
         Self::new(SmtConf::default_cvc4(), parser)
     }
@@ -247,7 +247,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// The command used to run a particular solver is up to the end-user. As such, it **does not
     /// make sense** to use default commands for anything else than local testing. You should
-    /// explicitely pass the command to use with [`Self::yices_2`](Self::yices_2) instead.
+    /// explicitely pass the command to use with [`Self::yices_2`] instead.
     pub fn default_yices_2(parser: Parser) -> SmtRes<Self> {
         Self::new(SmtConf::default_yices_2(), parser)
     }
@@ -260,7 +260,7 @@ impl<Parser> Solver<Parser> {
     /// Forces the solver to write all communications to a file.
     ///
     /// - fails if the solver is already tee-ed;
-    /// - see also [`path_tee`](Self::path_tee).
+    /// - see also [`Self::path_tee`].
     pub fn tee(&mut self, file: File) -> SmtRes<()> {
         if self.tee.is_some() {
             bail!("Trying to tee a solver that's already tee-ed")
@@ -279,7 +279,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// - opens `file` with `create` and `write`;
     /// - fails if the solver is already tee-ed;
-    /// - see also [`tee`](Self::tee).
+    /// - see also [`Self::tee`].
     pub fn path_tee<P>(&mut self, path: P) -> SmtRes<()>
     where
         P: AsRef<::std::path::Path>,
@@ -389,8 +389,8 @@ impl<Parser> Solver<Parser> {
     ///
     /// # See also
     ///
-    /// - [`print_check_sat`](Self::print_check_sat)
-    /// - [`parse_check_sat`](Self::parse_check_sat)
+    /// - [`Self::print_check_sat`]
+    /// - [`Self::parse_check_sat`]
     ///
     /// If you want a more natural way to handle unknown results, see `parse_check_sat_or_unk`.
     ///
@@ -428,7 +428,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// # See also
     ///
-    /// - [`parse_check_sat_or_unk`][Self::parse_check_sat_or_unk]
+    /// - [`Self::parse_check_sat_or_unk`]
     ///
     /// # Examples
     ///
@@ -576,7 +576,10 @@ impl<Parser> Solver<Parser> {
 
     /// Pushes `n` layers on the assertion stack.
     ///
-    /// - see also [`pop`](Self::pop).
+    /// - see also [`Self::pop`].
+    ///
+    /// Note that using [actlits][crate::actlit] is more efficient than push/pop, and is useable for
+    /// most push/pop use-cases.
     ///
     /// # Examples
     ///
@@ -608,7 +611,10 @@ impl<Parser> Solver<Parser> {
 
     /// Pops `n` layers off the assertion stack.
     ///
-    /// - see also [`push`](Self::push).
+    /// - see also [`Self::push`].
+    ///
+    /// Note that using [actlits][crate::actlit] is more efficient than push/pop, and is useable for
+    /// most push/pop use-cases.
     #[inline]
     pub fn pop(&mut self, n: u8) -> SmtRes<()> {
         tee_write! {
@@ -618,6 +624,8 @@ impl<Parser> Solver<Parser> {
     }
 
     /// Check-sat assuming command, turns `unknown` results into errors.
+    ///
+    /// - see also [actlits][crate::actlit].
     pub fn check_sat_assuming<'a, Ident, Idents>(&mut self, idents: Idents) -> SmtRes<bool>
     where
         Ident: ?Sized + Sym2Smt<()> + 'a,
@@ -627,6 +635,8 @@ impl<Parser> Solver<Parser> {
     }
 
     /// Check-sat assuming command, turns `unknown` results into `None`.
+    ///
+    /// - see also [actlits][crate::actlit].
     pub fn check_sat_assuming_or_unk<'a, Ident, Idents>(
         &mut self,
         idents: Idents,
@@ -894,11 +904,11 @@ impl<Parser> Solver<Parser> {
 
 /// # Actlit-Related Functions.
 ///
-/// See the [`actlit` module](super::actlit) for more details.
+/// See the [`actlit` module][crate::actlit] for more details.
 impl<Parser> Solver<Parser> {
     /// True if no actlits have been created since the last reset.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     fn has_actlits(&self) -> bool {
         self.actlit > 0
@@ -906,7 +916,7 @@ impl<Parser> Solver<Parser> {
 
     /// Introduces a new actlit.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     pub fn get_actlit(&mut self) -> SmtRes<Actlit> {
         let id = self.actlit;
@@ -923,7 +933,7 @@ impl<Parser> Solver<Parser> {
 
     /// Deactivates an activation literal, alias for `solver.set_actlit(actlit, false)`.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     pub fn de_actlit(&mut self, actlit: Actlit) -> SmtRes<()> {
         self.set_actlit(actlit, false)
@@ -931,7 +941,7 @@ impl<Parser> Solver<Parser> {
 
     /// Forces the value of an actlit and consumes it.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     pub fn set_actlit(&mut self, actlit: Actlit, b: bool) -> SmtRes<()> {
         tee_write! {
@@ -955,7 +965,7 @@ impl<Parser> Solver<Parser> {
 
     /// Asserts an expression without print information, guarded by an activation literal.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     pub fn assert_act<Expr>(&mut self, actlit: &Actlit, expr: &Expr) -> SmtRes<()>
     where
@@ -990,7 +1000,7 @@ impl<Parser> Solver<Parser> {
     /// Prints a check-sat command.
     ///
     /// Allows to print the `check-sat` and get the result later, *e.g.* with
-    /// [`parse_check_sat`](Self::parse_check_sat).
+    /// [`Self::parse_check_sat`].
     ///
     /// # Examples
     ///
@@ -1019,7 +1029,7 @@ impl<Parser> Solver<Parser> {
 
     /// Check-sat command, with actlits.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     pub fn print_check_sat_act<'a, Actlits>(&mut self, actlits: Actlits) -> SmtRes<FutureCheckSat>
     where
@@ -1274,7 +1284,7 @@ impl<Parser> Solver<Parser> {
 
 /// # Non-blocking commands.
 impl<Parser: Send + 'static> Solver<Parser> {
-    /// Asynchronous check-sat, see the [`asynch` module](crate::asynch) for details.
+    /// Asynchronous check-sat, see the [`asynch` module][crate::asynch] for details.
     ///
     /// This function is not `unsafe` in the sense that it **cannot** create undefined behavior.
     /// However, it is *unsafe* because the asynchronous check might end up running forever in the
@@ -1321,8 +1331,7 @@ impl<Parser> Solver<Parser> {
     ///
     /// # Examples
     ///
-    /// Note the use of [`define_null_sort`](Self::define_null_sort) to avoid problems with empty
-    /// arguments.
+    /// Note the use of [`Self::define_null_sort`] to avoid problems with empty arguments.
     ///
     /// ```
     /// # use rsmt2::Solver;
@@ -1383,12 +1392,9 @@ impl<Parser> Solver<Parser> {
 
     /// Defines a new nullary sort.
     ///
-    /// When using [`define_sort`](Self::define_sort), rust complains because it does not know what
-    /// the `Arg` type parameter is, since the `args` parameter is empty. So this function can be
-    /// useful.
-    ///
-    /// This could be fixed with a default type for `Arg`, like `Body` for instance, but this is
-    /// currently not possible in a function.
+    /// When using [`Self::define_sort`] with empty `args`, rust complains because it does not know
+    /// what the `Arg` type parameter is. This function addresses this problem by not having
+    /// arguments.
     #[inline]
     pub fn define_null_sort<Sort, Body>(&mut self, sort: &Sort, body: &Body) -> SmtRes<()>
     where
@@ -1701,7 +1707,7 @@ impl<Parser> Solver<Parser> {
 
     /// Asserts an expression with some print information, guarded by an activation literal.
     ///
-    /// See the [`actlit` module](super::actlit) for more details.
+    /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
     pub fn assert_act_with<Info, Expr>(
         &mut self,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -457,10 +457,10 @@ impl<Parser> Solver<Parser> {
     /// solver.declare_const("x", "Int").unwrap()
     /// ```
     #[inline]
-    pub fn declare_const<Sym, Sort>(&mut self, symbol: &Sym, out_sort: &Sort) -> SmtRes<()>
+    pub fn declare_const<Sym, Sort>(&mut self, symbol: Sym, out_sort: Sort) -> SmtRes<()>
     where
-        Sym: ?Sized + Sym2Smt<()>,
-        Sort: ?Sized + Sort2Smt,
+        Sym: Sym2Smt<()>,
+        Sort: Sort2Smt,
     {
         self.declare_const_with(symbol, out_sort, ())
     }
@@ -598,10 +598,10 @@ impl<Parser> Solver<Parser> {
     /// Check-sat assuming command, turns `unknown` results into errors.
     ///
     /// - see also [actlits][crate::actlit].
-    pub fn check_sat_assuming<'a, Ident, Idents>(&mut self, idents: Idents) -> SmtRes<bool>
+    pub fn check_sat_assuming<Ident, Idents>(&mut self, idents: Idents) -> SmtRes<bool>
     where
-        Ident: ?Sized + Sym2Smt<()> + 'a,
-        Idents: IntoIterator<Item = &'a Ident>,
+        Ident: Sym2Smt<()>,
+        Idents: IntoIterator<Item = Ident>,
     {
         self.check_sat_assuming_with(idents, ())
     }
@@ -609,13 +609,13 @@ impl<Parser> Solver<Parser> {
     /// Check-sat assuming command, turns `unknown` results into `None`.
     ///
     /// - see also [actlits][crate::actlit].
-    pub fn check_sat_assuming_or_unk<'a, Ident, Idents>(
+    pub fn check_sat_assuming_or_unk<Ident, Idents>(
         &mut self,
         idents: Idents,
     ) -> SmtRes<Option<bool>>
     where
-        Ident: ?Sized + Sym2Smt<()> + 'a,
-        Idents: IntoIterator<Item = &'a Ident>,
+        Ident: Sym2Smt<()>,
+        Idents: IntoIterator<Item = Ident>,
     {
         self.check_sat_assuming_or_unk_with(idents, ())
     }
@@ -686,10 +686,10 @@ impl<Parser> Solver<Parser> {
     ) -> SmtRes<()>
     where
         ArgSort: Sort2Smt + 'a,
-        OutSort: Sized + Sort2Smt,
-        FunSym: Sized + Sym2Smt<()>,
+        OutSort: Sort2Smt,
+        FunSym: Sym2Smt<()>,
         ArgSym: Sym2Smt<()> + 'a,
-        Body: Sized + Expr2Smt<()>,
+        Body: Expr2Smt<()>,
         Args: IntoIterator<Item = &'a (ArgSym, ArgSort)>,
     {
         self.define_fun_rec_with(symbol, args, out, body, ())
@@ -866,8 +866,8 @@ impl<Parser> Solver<Parser> {
     where
         Parser: for<'b> ExprParser<PExpr, (), &'b mut RSmtParser>
             + for<'b> ValueParser<PValue, &'b mut RSmtParser>,
-        Expr: ?Sized + Expr2Smt<()> + 'a,
-        Exprs: IntoIterator<Item = &'a Expr>,
+        Expr: Expr2Smt<()>,
+        Exprs: IntoIterator<Item = Expr>,
     {
         self.get_values_with(exprs, ())
             .map_err(|e| self.conf.enrich_get_values_error(e))
@@ -885,8 +885,8 @@ impl<Parser> Solver<Parser> {
         Info: Copy,
         Parser: for<'b> ExprParser<PExpr, Info, &'b mut RSmtParser>
             + for<'b> ValueParser<PValue, &'b mut RSmtParser>,
-        Expr: ?Sized + Expr2Smt<Info> + 'a,
-        Exprs: IntoIterator<Item = &'a Expr>,
+        Expr: Expr2Smt<Info>,
+        Exprs: IntoIterator<Item = Expr>,
     {
         self.print_get_values_with(exprs, info)?;
         self.parse_get_values_with(info)
@@ -1218,8 +1218,8 @@ impl<Parser> Solver<Parser> {
     ) -> SmtRes<()>
     where
         Info: Copy,
-        Expr: ?Sized + Expr2Smt<Info> + 'a,
-        Exprs: IntoIterator<Item = &'a Expr>,
+        Expr: Expr2Smt<Info>,
+        Exprs: IntoIterator<Item = Expr>,
     {
         tee_write! {
           self, |w| write!(w, "(get-value (") ?
@@ -1244,8 +1244,8 @@ impl<Parser> Solver<Parser> {
         bool_vars: Idents,
     ) -> SmtRes<FutureCheckSat>
     where
-        Ident: ?Sized + Sym2Smt<()> + 'a,
-        Idents: IntoIterator<Item = &'a Ident>,
+        Ident: Sym2Smt<()>,
+        Idents: IntoIterator<Item = Ident>,
     {
         self.print_check_sat_assuming_with(bool_vars, ())
     }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -345,9 +345,9 @@ impl<Parser> Solver<Parser> {
     /// solver.assert("(= 0 1)").unwrap();
     /// ```
     #[inline]
-    pub fn assert<Expr>(&mut self, expr: &Expr) -> SmtRes<()>
+    pub fn assert<Expr>(&mut self, expr: Expr) -> SmtRes<()>
     where
-        Expr: ?Sized + Expr2Smt<()>,
+        Expr: Expr2Smt<()>,
     {
         self.assert_with(expr, ())
     }
@@ -948,9 +948,9 @@ impl<Parser> Solver<Parser> {
     ///
     /// See the [`actlit` module][crate::actlit] for more details.
     #[inline]
-    pub fn assert_act<Expr>(&mut self, actlit: &Actlit, expr: &Expr) -> SmtRes<()>
+    pub fn assert_act<Expr>(&mut self, actlit: impl AsRef<Actlit>, expr: Expr) -> SmtRes<()>
     where
-        Expr: ?Sized + Expr2Smt<()>,
+        Expr: Expr2Smt<()>,
     {
         self.assert_act_with(actlit, expr, ())
     }
@@ -1720,18 +1720,18 @@ impl<Parser> Solver<Parser> {
     #[inline]
     pub fn assert_act_with<Info, Expr>(
         &mut self,
-        actlit: &Actlit,
-        expr: &Expr,
+        actlit: impl AsRef<Actlit>,
+        expr: Expr,
         info: Info,
     ) -> SmtRes<()>
     where
         Info: Copy,
-        Expr: ?Sized + Expr2Smt<Info>,
+        Expr: Expr2Smt<Info>,
     {
         tee_write! {
           self, |w| {
             write_str(w, "(assert\n  (=>\n    ")?;
-            actlit.write(w)?;
+            actlit.as_ref().write(w)?;
             write_str(w, "\n    ")?;
             expr.expr_to_smt2(w, info)?;
             write_str(w, "\n  )\n)\n") ?
@@ -1742,10 +1742,10 @@ impl<Parser> Solver<Parser> {
 
     /// Asserts an expression with some print information.
     #[inline]
-    pub fn assert_with<Info, Expr>(&mut self, expr: &Expr, info: Info) -> SmtRes<()>
+    pub fn assert_with<Info, Expr>(&mut self, expr: Expr, info: Info) -> SmtRes<()>
     where
         Info: Copy,
-        Expr: ?Sized + Expr2Smt<Info>,
+        Expr: Expr2Smt<Info>,
     {
         tee_write! {
           self, |w| {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -483,9 +483,9 @@ impl<Parser> Solver<Parser> {
     ) -> SmtRes<()>
     where
         FunSym: Sym2Smt<()>,
-        ArgSort: Sort2Smt + 'a,
+        ArgSort: Sort2Smt,
         OutSort: Sort2Smt,
-        Args: IntoIterator<Item = &'a ArgSort>,
+        Args: IntoIterator<Item = ArgSort>,
     {
         self.declare_fun_with(symbol, args, out, ())
     }
@@ -1258,8 +1258,8 @@ impl<Parser> Solver<Parser> {
     ) -> SmtRes<FutureCheckSat>
     where
         Info: Copy,
-        Ident: ?Sized + Sym2Smt<Info> + 'a,
-        Idents: IntoIterator<Item = &'a Ident>,
+        Ident: Sym2Smt<Info>,
+        Idents: IntoIterator<Item = Ident>,
     {
         match self.conf.get_check_sat_assuming() {
             Some(ref cmd) => {
@@ -1536,9 +1536,9 @@ impl<Parser> Solver<Parser> {
     where
         Info: Copy,
         FunSym: Sym2Smt<Info>,
-        ArgSort: Sort2Smt + 'a,
+        ArgSort: Sort2Smt,
         OutSort: Sort2Smt,
-        Args: IntoIterator<Item = &'a ArgSort>,
+        Args: IntoIterator<Item = ArgSort>,
     {
         tee_write! {
           self, |w| {
@@ -1915,15 +1915,15 @@ impl<Parser> Solver<Parser> {
     }
 
     /// Check-sat assuming command, turns `unknown` results into errors.
-    pub fn check_sat_assuming_with<'a, Info, Ident, Idents>(
+    pub fn check_sat_assuming_with<'a, Info, Sym, Syms>(
         &mut self,
-        idents: Idents,
+        idents: Syms,
         info: Info,
     ) -> SmtRes<bool>
     where
         Info: Copy,
-        Ident: ?Sized + Sym2Smt<Info> + 'a,
-        Idents: IntoIterator<Item = &'a Ident>,
+        Sym: Sym2Smt<Info>,
+        Syms: IntoIterator<Item = Sym>,
     {
         let future = self.print_check_sat_assuming_with(idents, info)?;
         self.parse_check_sat(future)
@@ -1937,8 +1937,8 @@ impl<Parser> Solver<Parser> {
     ) -> SmtRes<Option<bool>>
     where
         Info: Copy,
-        Ident: ?Sized + Sym2Smt<Info> + 'a,
-        Idents: IntoIterator<Item = &'a Ident>,
+        Ident: Sym2Smt<Info>,
+        Idents: IntoIterator<Item = Ident>,
     {
         let future = self.print_check_sat_assuming_with(idents, info)?;
         self.parse_check_sat_or_unk(future)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,9 +142,7 @@ pub mod z3 {
                  ",
             )
             .unwrap();
-        assert! {
-            ! solver.check_sat_assuming( Some("actlit") ).unwrap()
-        }
+        assert!(!solver.check_sat_assuming(Some("actlit")).unwrap());
         solver.assert("(not actlit)").unwrap();
 
         solver.declare_const("other_actlit", "Bool").unwrap();
@@ -157,9 +155,7 @@ pub mod z3 {
                  ",
             )
             .unwrap();
-        assert! {
-            solver.check_sat_assuming( Some("other_actlit") ).unwrap()
-        }
+        assert!(solver.check_sat_assuming(Some("other_actlit")).unwrap());
         solver.assert("(not other_actlit)").unwrap();
 
         solver.kill().unwrap()
@@ -179,9 +175,7 @@ pub mod z3 {
         solver.assert_act(&actlit, "(< x 3)").unwrap();
         solver.assert_act(&actlit, "(= (mod x 3) 0)").unwrap();
 
-        assert! {
-            ! solver.check_sat_act( Some(& actlit) ).unwrap()
-        }
+        assert!(!solver.check_sat_act(Some(&actlit)).unwrap());
         solver.de_actlit(actlit).unwrap();
         // At this point `actlit` has been consumed. So it's a bit safer than the
         // version above, since use-after-deactivate is not possible.
@@ -189,9 +183,7 @@ pub mod z3 {
         let actlit = solver.get_actlit().unwrap();
         solver.assert_act(&actlit, "(> x 7)").unwrap();
         solver.assert_act(&actlit, "(= (mod x 2) 0)").unwrap();
-        assert! {
-            solver.check_sat_act( Some(& actlit) ).unwrap()
-        }
+        assert!(solver.check_sat_act(Some(&actlit)).unwrap());
         solver.de_actlit(actlit).unwrap();
 
         solver.kill().unwrap()
@@ -267,18 +259,13 @@ pub mod yices_2 {
         let actlit = solver.get_actlit().expect("get actlit");
         let mut buf: Vec<u8> = vec![];
         actlit.write(&mut buf).unwrap();
-        assert_eq! {
-            "|rsmt2 actlit 0|",
-            ::std::str::from_utf8(& buf).unwrap()
-        }
+        assert_eq!("|rsmt2 actlit 0|", ::std::str::from_utf8(&buf).unwrap());
 
         solver.assert_act(&actlit, "(> x 7)").expect("assert act 1");
         solver
             .assert_act(&actlit, "(= (* x 2) 24)")
             .expect("assert act 2");
-        assert! {
-            solver.check_sat_act( Some(& actlit) ).expect("check sat act")
-        }
+        assert!(solver.check_sat_act(Some(&actlit)).expect("check sat act"));
 
         let model = solver.get_values(&["x"]).expect("get value");
 


### PR DESCRIPTION
Simplified many of the `Solver` functions, making many of them much more flexible. See the [changelog](https://github.com/kino-mc/rsmt2/blob/master/changes.md#v0131).

**NB:** breaking changes on `Solver::declare_datatypes`.