### PR TITLE
fix zombie solver processes on solver exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmt2"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Adrien Champion <adrien.champion@email.com>"]
 description = "Wrapper for SMT-LIB 2 compliant SMT solvers."
 documentation = "https://docs.rs/rsmt2"

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+# v0.14.1
+
+- properly `wait` for child solver process, [#29](https://github.com/kino-mc/rsmt2/issues/29)
+
 # v0.14.0
 
 - `Solver::get_interpolant` now mature enough for actual use (examples in doc)


### PR DESCRIPTION
See #29 

When killing the solver child process, rsmt2 now

- `try_wait`s for the process to terminate every 10s,
- gives up with an error after 1s (100 `try_wait`s).