### PR TITLE
Check success

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmt2"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Adrien Champion <adrien.champion@email.com>"]
 description = "Wrapper for SMT-LIB 2 compliant SMT solvers."
 documentation = "https://docs.rs/rsmt2"

--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,10 @@
-# v0.15.0
+# v0.16.0
+
+- fixed `success` handling, and added documentation
+- `success`-related `SmtConf` functions have been renamed, `print_success` and `parse_success` are
+    now `check_success`
+
+# v0.15.1
 
 - `eof` token has been renamed to `eoi`
 - fixed a bug in SMT-level error parsing

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use std::{fmt, io};
 
 use crate::prelude::*;
 
-/// SMT Lib 2 logics, used with [`Solver::set_logic`][crate::Solver::set_logic].
+/// SMT-LIB 2 logics, used with [`Solver::set_logic`][crate::Solver::set_logic].
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy)]
 pub enum Logic {
@@ -56,7 +56,7 @@ impl fmt::Display for Logic {
     }
 }
 impl Logic {
-    /// Prints the logic in a writer in SMT Lib 2 format.
+    /// Prints the logic in a writer in SMT-LIB 2 format.
     pub fn to_smt2<W: io::Write>(self, writer: &mut W, _: ()) -> SmtRes<()> {
         write!(writer, "{}", self)?;
         Ok(())

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -88,7 +88,7 @@ impl SmtStyle {
                 options: vec!["-in".into(), "-smt2".into()],
                 models: true,
                 incremental: true,
-                parse_success: false,
+                check_success: false,
                 unsat_cores: false,
                 interpolants: true,
                 check_sat_assuming: supported("check-sat-assuming"),
@@ -104,7 +104,7 @@ impl SmtStyle {
                 ],
                 models: false,
                 incremental: false,
-                parse_success: false,
+                check_success: false,
                 unsat_cores: false,
                 interpolants: false,
                 check_sat_assuming: unsupported(),
@@ -115,7 +115,7 @@ impl SmtStyle {
                 options: vec![],
                 models: false,
                 incremental: false,
-                parse_success: false,
+                check_success: false,
                 unsat_cores: false,
                 interpolants: false,
                 check_sat_assuming: supported("check-sat-assuming"),
@@ -225,7 +225,7 @@ pub struct SmtConf {
     /// Incrementality.
     incremental: bool,
     /// Parse success.
-    parse_success: bool,
+    check_success: bool,
     /// Triggers unsat-core production.
     unsat_cores: bool,
     /// Triggers interpolant production.
@@ -761,48 +761,45 @@ impl SmtConf {
         self.check_sat_assuming.as_ref().map(|s| *s)
     }
 
-    /// Indicates if print success is active.
+    /// Indicates if success-checking is active, see [`Solver`](crate::Solver#check-success).
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use rsmt2::SmtConf;
-    /// assert!(! SmtConf::default_z3().get_print_success());
+    /// assert!(! SmtConf::default_z3().get_check_success());
     /// ```
     #[inline]
-    #[cfg(not(no_parse_success))]
-    pub fn get_print_success(&self) -> bool {
-        self.parse_success
+    pub fn get_check_success(&self) -> bool {
+        self.check_success
     }
-    /// Activates parse sucess.
+    /// Activates success-checking, see [`Solver`](crate::Solver#check-success).
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
-    /// conf.print_success();
-    /// assert!(conf.get_print_success());
+    /// conf.check_success();
+    /// assert!(conf.get_check_success());
     /// ```
     #[inline]
-    #[cfg(not(no_parse_success))]
-    pub fn print_success(&mut self) {
-        self.set_print_success(true)
+    pub fn check_success(&mut self) {
+        self.set_check_success(true)
     }
-    /// (De)activates parse sucess.
+    /// (De)activates sucess-checking, see [`Solver`](crate::Solver#check-success).
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use rsmt2::SmtConf;
     /// let mut conf = SmtConf::default_z3();
-    /// conf.set_print_success(true);
-    /// assert!(conf.get_print_success());
+    /// conf.set_check_success(true);
+    /// assert!(conf.get_check_success());
     /// ```
     #[inline]
-    #[cfg(not(no_parse_success))]
-    pub fn set_print_success(&mut self, val: bool) {
-        self.parse_success = val
+    pub fn set_check_success(&mut self, val: bool) {
+        self.check_success = val
     }
 
     /// Indicates if interpolant production is active.

--- a/src/examples/simple.rs
+++ b/src/examples/simple.rs
@@ -11,9 +11,9 @@
 //! ## Print functions
 //!
 //! Since the structure for S-expressions is provided by users, they also need to provide functions
-//! to print it in SMT Lib 2.
+//! to print it in SMT-LIB 2.
 //!
-//! To use all SMT Lib 2 commands in a type-safe manner, the library requires printers over
+//! To use all SMT-LIB 2 commands in a type-safe manner, the library requires printers over
 //!
 //! - sorts: [`Sort2Smt`](crate::print::Sort2Smt) trait, *e.g.* for
 //!   [`Solver::declare_fun`](crate::Solver::declare_fun),
@@ -336,15 +336,25 @@ use crate::examples::get_solver;
 /// Operators. Just implements `Display`, never manipulated directly by the solver.
 #[derive(Copy, Clone)]
 pub enum Op {
+    /// Addition.
     Add,
+    /// Subtraction.
     Sub,
+    /// Multiplication.
     Mul,
+    /// Conjunction.
     Conj,
+    /// Disjunction.
     Disj,
+    /// Equality.
     Eql,
+    /// Greater than or equal to.
     Ge,
+    /// Greater than.
     Gt,
+    /// Less than.
     Lt,
+    /// Less than or equal to.
     Le,
 }
 impl ::std::fmt::Display for Op {
@@ -402,6 +412,7 @@ pub enum Expr {
     O(Op, Vec<Expr>),
 }
 impl Expr {
+    /// Constant constructor.
     pub fn cst<C: Into<Cst>>(c: C) -> Self {
         Expr::C(c.into())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A wrapper around SMT Lib 2(.5)-compliant SMT solvers.
+//! A wrapper around SMT-LIB 2(.5)-compliant SMT solvers.
 //!
 //! See [`CHANGES.md`][changes] for the list of changes.
 //!

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-//! SMT Lib 2 result parsers.
+//! SMT-LIB 2 result parsers.
 //!
 //! Depending on the commands you plan to use, your parser will need to implement
 //!
@@ -545,12 +545,9 @@ impl<R: BufRead> SmtParser<R> {
     ///
     /// Returns `()` exactly when [`Self::try_tag`] returns `true`, and an error otherwise.
     pub fn tag_info(&mut self, tag: &str, err_msg: &str) -> SmtRes<()> {
-        println!("  try_tag(`{}`)", tag);
         if self.try_tag(tag)? {
-            println!("  - got it");
             Ok(())
         } else {
-            println!("  - fail time");
             self.fail_with(format!("expected `{}` {}", tag, err_msg))
         }
     }
@@ -1336,27 +1333,18 @@ impl<R: BufRead> SmtParser<R> {
         self.tag("(")?;
         self.try_tag("model")?;
         while !self.try_tag(")")? {
-            println!("1");
             self.tag_info("(", "opening define-fun or `)` closing model")?;
-            println!("2");
             self.tag("define-fun")?;
-            println!("3");
 
             if prune_actlits && self.try_actlit_id()? {
-                println!("4.1");
                 self.tags(&["(", ")"])?;
                 self.tag("Bool")?;
                 self.bool()?;
             } else {
-                println!("5.1");
                 let id = parser.parse_ident(self)?;
-                println!("5.2");
                 self.tags(&["(", ")"])?;
-                println!("5.3");
                 let typ = parser.parse_type(self)?;
-                println!("5.4");
                 let value = parser.parse_value(self, &id, &[], &typ)?;
-                println!("5.5");
                 model.push((id, typ, value));
             }
             self.tag(")")?;

--- a/src/print.rs
+++ b/src/print.rs
@@ -16,7 +16,7 @@ pub use crate::{errors::*, prelude::*};
 /// Type of a model.
 pub type Model<Ident, Type, Value> = Vec<(Ident, Vec<(Ident, Type)>, Type, Value)>;
 
-/// A symbol printable in the SMT Lib 2 standard given some info.
+/// A symbol printable in the SMT-LIB 2 standard given some info.
 pub trait Sym2Smt<Info = ()> {
     /// Prints a symbol to a writer given some info.
     fn sym_to_smt2<Writer>(&self, w: &mut Writer, i: Info) -> SmtRes<()>
@@ -24,7 +24,7 @@ pub trait Sym2Smt<Info = ()> {
         Writer: io::Write;
 }
 
-/// An expression printable in the SMT Lib 2 standard given some info.
+/// An expression printable in the SMT-LIB 2 standard given some info.
 pub trait Expr2Smt<Info = ()> {
     /// Prints an expression to a writer given some info.
     fn expr_to_smt2<Writer>(&self, w: &mut Writer, i: Info) -> SmtRes<()>
@@ -49,7 +49,7 @@ pub trait Expr2Smt<Info = ()> {
     }
 }
 
-/// A sort printable in the SMT Lib 2 standard.
+/// A sort printable in the SMT-LIB 2 standard.
 pub trait Sort2Smt {
     /// Prints a sort to a writer info.
     fn sort_to_smt2<Writer>(&self, w: &mut Writer) -> SmtRes<()>


### PR DESCRIPTION
Finally added support for print/parse `success` for accurate error-reporting