### PR TITLE
Mark CVC4 as supporting check-sat-assuming

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -58,7 +58,7 @@ fn get_env_var(env_var: &str) -> SmtRes<Option<String>> {
 /// - [yices 2][yices 2]: full support in theory, but only partially tested. Command `get-model`
 ///   will only work on Yices 2 > `2.6.1`, and needs to be activated in [`SmtConf`] with
 ///   [`SmtConf::models`]. To understand why, see <https://github.com/SRI-CSL/yices2/issues/162>.
-///   
+///
 /// [z3]: https://github.com/Z3Prover/z3 (z3 github repository)
 /// [cvc4]: https://cvc4.github.io/ (cvc4 github pages)
 /// [yices 2]: https://yices.csl.sri.com/ (yices 2 official page)
@@ -107,7 +107,7 @@ impl SmtStyle {
                 check_success: false,
                 unsat_cores: false,
                 interpolants: false,
-                check_sat_assuming: unsupported(),
+                check_sat_assuming: supported("check-sat-assuming"),
             },
             Yices2 => SmtConf {
                 style: self,
@@ -208,7 +208,7 @@ impl fmt::Display for SmtStyle {
 /// - [yices 2]: full support in theory, but only partially tested. Command `get-model`
 ///   will only work on Yices 2 > `2.6.1`, and needs to be activated with [`Self::models`]. To
 ///   understand why, see <https://github.com/SRI-CSL/yices2/issues/162>.
-///   
+///
 /// [z3]: https://github.com/Z3Prover/z3 (z3 github repository)
 /// [cvc4]: https://cvc4.github.io/ (cvc4 github pages)
 /// [yices 2]: https://yices.csl.sri.com/ (yices 2 official page)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -82,6 +82,41 @@ pub mod cvc4 {
             ),
         }
     }
+
+    #[test]
+    fn actlits_0() {
+        let mut conf = SmtConf::default_cvc4();
+        conf.incremental();
+        let mut solver = Solver::new(conf, ()).unwrap();
+        solver.declare_const("x", "Int").unwrap();
+
+        let actlit = solver.get_actlit().unwrap();
+        solver.declare_const("actlit", "Bool").unwrap();
+        solver
+            .assert_act(
+                &actlit,
+                "\
+                 (and (> x 0) (< x 3) (= (mod x 3) 0))\
+                 ",
+            )
+            .unwrap();
+        assert!(!solver.check_sat_act(Some(&actlit)).unwrap());
+        solver.de_actlit(actlit).unwrap();
+
+        let actlit = solver.get_actlit().unwrap();
+        solver
+            .assert_act(
+                &actlit,
+                "\
+                 (and (> x 7) (= (mod x 2) 0))\
+                 ",
+            )
+            .unwrap();
+        assert!(solver.check_sat_act(Some(&actlit)).unwrap());
+        solver.de_actlit(actlit).unwrap();
+
+        solver.kill().unwrap()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It looks like CVC4 does now support `check-sat-assuming`, as of https://github.com/cvc5/cvc5/pull/1637. This PR adds support for it and adds a test using activation literals.

Here's a small test file that CVC4 correctly produces unsat for:

```smt2
; Command:
; > z3 -in -smt2

(set-logic ALL)

(declare-fun p ( 
) Bool)

(declare-fun q ( 
) Bool)

(assert
    (and (not p) (not q) (and (= p (or p q)) (= q q)))
)

(declare-fun |rsmt2 actlit 0| () Bool)

(assert (=> |rsmt2 actlit 0|
    (not (not p))
))

(check-sat-assuming (
 |rsmt2 actlit 0|
) )

(assert (not |rsmt2 actlit 0|) )

(assert
    (not p)
)
```