### PR TITLE
remove `&str` parsing impls to avoid breakage in future Rust versions.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1551,17 +1551,6 @@ where
         self.parse_type(input.get_sexpr()?)
     }
 }
-impl<'a, Br> IdentParser<&'a str, &'a str, &'a mut SmtParser<Br>> for ()
-where
-    Br: BufRead,
-{
-    fn parse_ident(self, input: &'a mut SmtParser<Br>) -> SmtRes<&'a str> {
-        input.get_sexpr()
-    }
-    fn parse_type(self, input: &'a mut SmtParser<Br>) -> SmtRes<&'a str> {
-        input.get_sexpr()
-    }
-}
 impl<'a, Br> IdentParser<String, String, &'a mut SmtParser<Br>> for ()
 where
     Br: BufRead,
@@ -1625,20 +1614,6 @@ where
         output: &Type,
     ) -> SmtRes<Value> {
         self.parse_value(input.get_sexpr()?, name, inputs, output)
-    }
-}
-impl<'a, Br> ModelParser<&'a str, &'a str, &'a str, &'a mut SmtParser<Br>> for ()
-where
-    Br: BufRead,
-{
-    fn parse_value(
-        self,
-        input: &'a mut SmtParser<Br>,
-        _name: &&'a str,
-        _inputs: &[(&'a str, &'a str)],
-        _output: &&'a str,
-    ) -> SmtRes<&'a str> {
-        input.get_sexpr()
     }
 }
 impl<'a, Br> ModelParser<String, String, String, &'a mut SmtParser<Br>> for ()


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/pull/119820 this crate will likely start to fail to compile due to ambiguity errors. More specifically, `SmtParser::get_model` currently always infers `Ident`, `Value` and `Type` to `String` if `Parser` is `()`. This will stop being the case:

There are two impls of `IdentParser` (this also affects `ModelParser`) for `()`:

https://github.com/kino-mc/rsmt2/blob/2f1168a3839f7d7a6c5a24e3740a5d5836b8d26c/src/parse.rs#L1554

https://github.com/kino-mc/rsmt2/blob/2f1168a3839f7d7a6c5a24e3740a5d5836b8d26c/src/parse.rs#L1565

`fn get_model` requires `Parser: for<'p> IdentParser<Ident, Type, &'p mut RSmtParser>`. Using `()` as the `Parser` this results in a `(): for<'p> IdentParser<_, _, &'p mut RSmtParser>` obligation.

While it looks like both impls should apply here, the first impl actually results in a higher-ranked region error. The impl allows you to prove `(): for<'p> IdentParser<&'p str, &'p str, &'p mut RSmtParser>`, but the inference variables for `Ident` and `Type` cannot name `'p`.

The impl would have to be for `impl<'a, 'b, Br> IdentParser<&'b str, &'b str, &'a mut SmtParser<Br>> for ()` instead, as now the inferred types for `Ident` and `Type` can use an unrelated lifetime.

This higher-ranked region error previously caused us to eagerly discard the first impl, using the second impl to guide type inference. This was unintended and will stop being the case once https://github.com/rust-lang/rust/pull/119820 lands. Please ask for clarification if you would like further information. I apologize for the inconvenience.

As this means that the first impl can not be used by `fn get_model`, I ended up removing these impls to avoid this ambiguity in future Rust versions. I am not sure whether that's the best way forward and whether these impls are usable anywhere else. However, removing them seemed to not cause any compilation errors when running `cargo test`, so hopefully that's fine.